### PR TITLE
Remove CleanMyMac from the list of malwares.

### DIFF
--- a/removeMalware.sh
+++ b/removeMalware.sh
@@ -12,7 +12,7 @@ echo ${VERSION}
 echo Developed by: Luke Milius
 
 ##--Lists the filenames to search for, space delimited. --#
-ARGS="mackeeper zeobit mplayer vsearch justcloud zipcloud palmall cleanmymac searchprotect kromtech genieo flashmall macvax installmac cinemas cinemapro sophos omnibar searchme tuneupmymac adwaremedic installmc thesafemac crossrider K9-optimizer K9-MacOptimizer duckduckgo zeospace"
+ARGS="mackeeper zeobit mplayer vsearch justcloud zipcloud palmall searchprotect kromtech genieo flashmall macvax installmac cinemas cinemapro sophos omnibar searchme tuneupmymac adwaremedic installmc thesafemac crossrider K9-optimizer K9-MacOptimizer duckduckgo zeospace"
 echo finding: ${ARGS} in Applications and Libraries
 
 ##--Find all associated files that contain the given arguments and print them to the screen --##
@@ -23,7 +23,7 @@ find /Applications -maxdepth 1 -iname "*${malware}*" -print >> ~/Desktop/ItemsTo
 done
 
 echo Searching Libraries...	
-find ~ /Library /System/Library \( -iname "*mackeeper*" -o -iname "*zeobit*" -o -iname "*mplayerx*" -o -iname "*vsearch*" -o -iname "*justcloud*" -o -iname "*zipcloud*" -o -iname "*palmall*" -o -iname "*cleanmymac*" -o -iname "*searchprotect*" -o -iname "*kromtech*" -o -iname "*genieo*" -o -iname "*flashmall*" -o -iname "*macvax*" -o -iname "*installmac*" -o -iname "*cinemas*" -o -iname "*omnibar*" -o -iname "*cinemapro*" -o -iname "*tuneupmymac*" -o -iname "*adwaremedic*" -o -iname "*installmc*" -o -iname "*thesafemac*" -o -iname "*crossrider*" -o -iname "*duckduckgo*" -o -iname "*k9-optimizer*" -o -iname "*k9-macoptimizer*" -o -iname "*zeospace*" -o -iname "*sophos*" \) -print >> ~/Desktop/ItemsToDelete/files.txt
+find ~ /Library /System/Library \( -iname "*mackeeper*" -o -iname "*zeobit*" -o -iname "*mplayerx*" -o -iname "*vsearch*" -o -iname "*justcloud*" -o -iname "*zipcloud*" -o -iname "*palmall*" -o -iname "*searchprotect*" -o -iname "*kromtech*" -o -iname "*genieo*" -o -iname "*flashmall*" -o -iname "*macvax*" -o -iname "*installmac*" -o -iname "*cinemas*" -o -iname "*omnibar*" -o -iname "*cinemapro*" -o -iname "*tuneupmymac*" -o -iname "*adwaremedic*" -o -iname "*installmc*" -o -iname "*thesafemac*" -o -iname "*crossrider*" -o -iname "*duckduckgo*" -o -iname "*k9-optimizer*" -o -iname "*k9-macoptimizer*" -o -iname "*zeospace*" -o -iname "*sophos*" \) -print >> ~/Desktop/ItemsToDelete/files.txt
 
 awk '!a[$0]++' ~/Desktop/ItemsToDelete/files.txt >> ~/Desktop/ItemsToDelete/filesToDelete.txt
 cat ~/Desktop/ItemsToDelete/filesToDelete.txt


### PR DESCRIPTION
Hello Luke,

Thank you for your MacMalwareRemoval tool. Today I downloaded it when trying to uninstall zipcloud and noticed that our application CleanMyMac is included as a Mac Malware. CleanMyMac has  been in the market for over 6 years now, and we have more than 500K loyal users. CleanMyMac is a legitimate piece of software, intended to help users clean and maintain their Mac. I understand that you might be confusing CleanMyMac with other aggressive cleaners out there, but rest assured that we have never used any aggressive tactics while promoting our applications. 

Our company's most value asset is our reputation, and we cherish it. That is why I kindly request you to remove CleanMyMac from your malware detecting script.

Thanks,
Vera Tkachenko
CleanMyMac Developer
