### PR TITLE
Added adware sources, dynamic generation of string for library searching

### DIFF
--- a/removeMalware.sh
+++ b/removeMalware.sh
@@ -2,7 +2,7 @@
 
 #---VERSION INFO----
 DATE=$(date +"%Y%m%d%H%M")
-VERSION="Version 2.0.6"
+VERSION="Version 2.0.7"
 mkdir ~/Desktop/ItemsToDelete
 
 DIRECTORY=$(cd `dirname .` && pwd)
@@ -12,7 +12,7 @@ echo ${VERSION}
 echo Developed by: Luke Milius
 
 ##--Lists the filenames to search for, space delimited. --#
-ARGS="mackeeper zeobit mplayer vsearch justcloud zipcloud palmall searchprotect kromtech genieo flashmall macvax installmac cinemas cinemapro sophos omnibar searchme tuneupmymac adwaremedic installmc thesafemac crossrider K9-optimizer K9-MacOptimizer duckduckgo zeospace"
+ARGS="codec-m yontoo chatzum conduit mybrand trovi searchtab omnibar savekeep vidx walletbee toppy updatedownloader cleanmymac macwarrior macreviver mediadownloader mackeeper zeobit mplayer vsearch justcloud zipcloud palmall searchprotect kromtech genieo flashmall macvax installmac cinemas cinemapro sophos omnibar searchme tuneupmymac adwaremedic installmc thesafemac crossrider K9-optimizer K9-MacOptimizer duckduckgo zeospace"
 echo finding: ${ARGS} in Applications and Libraries
 
 ##--Find all associated files that contain the given arguments and print them to the screen --##
@@ -22,8 +22,19 @@ echo Searching Applications based on: ${malware}
 find /Applications -maxdepth 1 -iname "*${malware}*" -print >> ~/Desktop/ItemsToDelete/files.txt
 done
 
+
+for last in $ARGS; do true; done
 echo Searching Libraries...	
-find ~ /Library /System/Library \( -iname "*mackeeper*" -o -iname "*zeobit*" -o -iname "*mplayerx*" -o -iname "*vsearch*" -o -iname "*justcloud*" -o -iname "*zipcloud*" -o -iname "*palmall*" -o -iname "*searchprotect*" -o -iname "*kromtech*" -o -iname "*genieo*" -o -iname "*flashmall*" -o -iname "*macvax*" -o -iname "*installmac*" -o -iname "*cinemas*" -o -iname "*omnibar*" -o -iname "*cinemapro*" -o -iname "*tuneupmymac*" -o -iname "*adwaremedic*" -o -iname "*installmc*" -o -iname "*thesafemac*" -o -iname "*crossrider*" -o -iname "*duckduckgo*" -o -iname "*k9-optimizer*" -o -iname "*k9-macoptimizer*" -o -iname "*zeospace*" -o -iname "*sophos*" \) -print >> ~/Desktop/ItemsToDelete/files.txt
+string=""
+for malware in $ARGS do
+if [ "$malware" != "$last" ] 
+then
+  string=$string"-iname *${malware}* -o "
+else
+  string=$string"-iname *${malware}*"
+fi
+done
+find ~ /Library /System/Library $string -print >> ~/Desktop/ItemsToDelete/files.txt
 
 awk '!a[$0]++' ~/Desktop/ItemsToDelete/files.txt >> ~/Desktop/ItemsToDelete/filesToDelete.txt
 cat ~/Desktop/ItemsToDelete/filesToDelete.txt
@@ -47,4 +58,3 @@ echo Files Removed!
 exit
 
 #------
-


### PR DESCRIPTION
Hello,

I've adapted your script for use in my tech support role, and thought I'd give back by suggesting the implementation of changes I made!
1. I've added some more common mac malware sources to your list, one popular [reference](http://www.thesafemac.com/arg-identification/) I used.
2. I made it so the string used to search the library is dynamically generated. This makes it a bit longer, but significantly easier to drop in new malware sources in the future.

It's a script so I did it quick and dirty, but let me know your thoughts!

Best,
Ramimac
